### PR TITLE
Use port 630 for WireGuard

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -28,7 +28,7 @@ fi
 
 # WireGuard — серверные параметры
 SERVER_WG_ADDR="10.100.10.1/24"   # та же /24, что и VPN_NETWORK в сервисе
-SERVER_LISTEN_PORT="630"
+SERVER_LISTEN_PORT="80"
 
 # Генерируем секреты / переменные окружения
 API_TOKEN=$(openssl rand -hex 32)

--- a/install.sh
+++ b/install.sh
@@ -28,7 +28,7 @@ fi
 
 # WireGuard — серверные параметры
 SERVER_WG_ADDR="10.100.10.1/24"   # та же /24, что и VPN_NETWORK в сервисе
-SERVER_LISTEN_PORT="51820"
+SERVER_LISTEN_PORT="630"
 
 # Генерируем секреты / переменные окружения
 API_TOKEN=$(openssl rand -hex 32)

--- a/wg_service.py
+++ b/wg_service.py
@@ -43,7 +43,7 @@ MYSQL_PASS: str = os.getenv("MYSQL_PASSWORD", "wg_pass")
 WG_INTERFACE: str = os.getenv("WG_INTERFACE", "wg0")
 SERVER_PUBLIC_KEY: str = os.getenv("SERVER_PUBLIC_KEY", "<server‑pubkey>")
 SERVER_ENDPOINT_IP: str = os.getenv("SERVER_ENDPOINT_IP", "1.2.3.4")
-SERVER_ENDPOINT_PORT: int = int(os.getenv("SERVER_ENDPOINT_PORT", "630"))
+SERVER_ENDPOINT_PORT: int = int(os.getenv("SERVER_ENDPOINT_PORT", "80"))
 
 VPN_NETWORK_STR: str = os.getenv("VPN_NETWORK", "10.100.10.0/24")
 DNS_SERVERS: str = os.getenv("DNS_SERVERS", "8.8.8.8")

--- a/wg_service.py
+++ b/wg_service.py
@@ -43,7 +43,7 @@ MYSQL_PASS: str = os.getenv("MYSQL_PASSWORD", "wg_pass")
 WG_INTERFACE: str = os.getenv("WG_INTERFACE", "wg0")
 SERVER_PUBLIC_KEY: str = os.getenv("SERVER_PUBLIC_KEY", "<server‑pubkey>")
 SERVER_ENDPOINT_IP: str = os.getenv("SERVER_ENDPOINT_IP", "1.2.3.4")
-SERVER_ENDPOINT_PORT: int = int(os.getenv("SERVER_ENDPOINT_PORT", "51830"))
+SERVER_ENDPOINT_PORT: int = int(os.getenv("SERVER_ENDPOINT_PORT", "630"))
 
 VPN_NETWORK_STR: str = os.getenv("VPN_NETWORK", "10.100.10.0/24")
 DNS_SERVERS: str = os.getenv("DNS_SERVERS", "8.8.8.8")


### PR DESCRIPTION
## Summary
- Update default WireGuard listen port to 630 in installation script and service

## Testing
- `python -m py_compile wg_service.py`
- `bash -n install.sh`


------
https://chatgpt.com/codex/tasks/task_e_689242c704a0832f875c4bb63d85c781