### PR TITLE
Use port 21 for OpenVPN

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -27,7 +27,8 @@ if [[ -z "$PUBLIC_IP" ]]; then
 fi
 
 SERVER_NETWORK="10.100.10.0 255.255.255.0"
-SERVER_PORT="1194"
+# Default OpenVPN listening port
+SERVER_PORT="21"
 
 API_TOKEN=$(openssl rand -hex 32)
 MYSQL_PASSWORD=$(openssl rand -hex 16)

--- a/ovpn_service.py
+++ b/ovpn_service.py
@@ -30,7 +30,8 @@ MYSQL_USER: str = os.getenv("MYSQL_USER", "ovpn_user")
 MYSQL_PASS: str = os.getenv("MYSQL_PASSWORD", "ovpn_pass")
 
 SERVER_ENDPOINT_IP: str = os.getenv("SERVER_ENDPOINT_IP", "1.2.3.4")
-SERVER_ENDPOINT_PORT: int = int(os.getenv("SERVER_ENDPOINT_PORT", "1194"))
+# Default OpenVPN server port
+SERVER_ENDPOINT_PORT: int = int(os.getenv("SERVER_ENDPOINT_PORT", "21"))
 DNS_SERVERS: str = os.getenv("DNS_SERVERS", "8.8.8.8")
 
 EASYRSA_DIR: Path = Path(os.getenv("EASYRSA_DIR", "/etc/openvpn/easy-rsa"))


### PR DESCRIPTION
## Summary
- default OpenVPN port changed to 21 in install script
- service defaults to port 21 when building client configs

## Testing
- `python -m py_compile ovpn_service.py`
- `bash -n install.sh`


------
https://chatgpt.com/codex/tasks/task_e_68931a38fc8c832fa130cf09e1ff0d67